### PR TITLE
Electron ID for 2018

### DIFF
--- a/grinder/utils/ids.py
+++ b/grinder/utils/ids.py
@@ -34,7 +34,7 @@ def isTightElectron(pt,eta,dxy,dz,iso,tight_id,year):
     elif year=='2017':
         return ((pt>30)&(abs(eta)<2.4)&(abs(dxy)<0.05)&(abs(dz)<0.2)&(tight_id))
     elif year=='2018':
-        return ((pt>40)&(abs(eta)<2.5)&(tight_id))
+        return ((pt>35)&(abs(eta)<2.5)&(tight_id))
     return mask
 
 mu_id = {}


### PR DESCRIPTION
From https://twiki.cern.ch/twiki/bin/view/CMS/EgammaRunIIRecommendations

Everything is fine, only change was the electron tight pt cut (why use 40? the trigger is HLT_Ele32_WPTight_Gsf_v, so pt > 35 GeV) should be fine).

Regarding the "loose ID" - what is it used for? I am a bit scared about the pt cuts (they seem low, especially they are lower than the trigger) and the fact that there is some interplay in between the ID at the trigger and the ID we want to use at selection level (i.e., we should not use "loose ID" if we are coming from a "Tight" trigger.