### PR TITLE
MET filters implementation

### DIFF
--- a/grinder/utils/metfilters.py
+++ b/grinder/utils/metfilters.py
@@ -1,0 +1,27 @@
+###
+# From https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2
+###
+
+met_filter_flags = {}
+met_filter_flags["2016"] = ["Flag_goodVertices",
+                            "Flag_globalSuperTightHalo2016Filter",
+                            "Flag_HBHENoiseFilter",
+                            "Flag_HBHENoiseIsoFilter",
+                            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+                            ]
+
+met_filter_flags["2017"] = ["Flag_goodVertices",
+                            "Flag_globalSuperTightHalo2016Filter",
+                            "Flag_HBHENoiseFilter",
+                            "Flag_HBHENoiseIsoFilter",
+                            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+                            "Flag_BadPFMuonFilter",
+                            ]
+
+met_filter_flags["2018"] = ["Flag_goodVertices",
+                            "Flag_globalSuperTightHalo2016Filter",
+                            "Flag_HBHENoiseFilter",
+                            "Flag_HBHENoiseIsoFilter",
+                            "Flag_EcalDeadCellTriggerPrimitiveFilter",
+                            "Flag_BadPFMuonFilter",
+                            ]


### PR DESCRIPTION
From https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2

Notice that we are not applying the "ECAL bad calibration filter update", since it has to be rerun on MINIAOD, and I am not sure that we did it for our NanoAOD production. To be revisited.