### PR TITLE
Muon IDs for 2017 and 2016

### DIFF
--- a/grinder/utils/ids.py
+++ b/grinder/utils/ids.py
@@ -52,23 +52,25 @@ mu_id['2018']['iso'] = 'Muon_pfRelIso04_all'
 mu_id['2018']['tight_id'] = 'Muon_tightId'
 
 def isLooseMuon(pt,eta,dxy,dz,iso,year):
+    #dxy and dz cuts are missing from loose_id; very loose isolation is 0.4
     mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
     if year=='2016':
-        mask = (pt>5)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
+        mask = (pt>20)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
     elif year=='2017':
-        mask = (pt>5)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
+        mask = (pt>20)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
     elif year=='2018':
-        mask = (pt>20)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4) #dxy and dz cuts are missing from loose_id; very loose isolation is 0.4
+        mask = (pt>20)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
     return mask
 
 def isTightMuon(pt,eta,dxy,dz,iso,tight_id,year):
+    #dxy and dz cuts are baked on tight_id; tight isolation is 0.15
     mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
     if year=='2016':
-        mask = (pt>5)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
+        mask = (pt>20)&(abs(eta)<2.4)&(tight_id)&(iso<0.15)
     elif year=='2017':
-        mask = (pt>5)&(abs(eta)<2.4)&(abs(dxy)<0.5)&(abs(dz)<1.0)&(iso<0.4)
+        mask = (pt>20)&(abs(eta)<2.4)&(tight_id)&(iso<0.15)
     elif year=='2018':
-        mask = (pt>20)&(abs(eta)<2.4)&(tight_id)&(iso<0.15) #dxy and dz cuts are baked on tight_id; tight isolation is 0.15
+        mask = (pt>20)&(abs(eta)<2.4)&(tight_id)&(iso<0.15)
     return mask
 
 tau_id = {}


### PR DESCRIPTION
   * muon ID is the same for all of Run 2
   * pt cuts made uniform at 20 GeV for both loose and tight muons
   * (relative PF, delta-beta corrected, cone=0.4) tight isolation of 0.15 for tight muons
   * (same) very loose isolation of 0.4 for loose muons
   * loose dxy, dz cuts (0.5, 1.0) for loose muons. Cuts are already baked in tight muons