### PR TITLE
Tau IDs for 2017 and 2016

### DIFF
--- a/grinder/utils/ids.py
+++ b/grinder/utils/ids.py
@@ -87,9 +87,9 @@ tau_id['2018']['decayMode'] = 'Tau_idDecayMode'
 def isLooseTau(pt,eta,decayMode,_id,year):
     mask = ~(pt==np.nan)#just a complicated way to initialize a jagged array with the needed shape to True
     if year=='2016':
-        mask = (pt>18)&(abs(eta)<2.3)&(decayMode)#&((_id&2)!=0)
+        mask = (pt>20)&(abs(eta)<2.3)&(decayMode)&((_id&2)!=0)
     elif year=='2017':
-        mask = (pt>20)&(abs(eta)<2.3)&(decayMode)
+        mask = (pt>20)&(abs(eta)<2.3)&(decayMode)&((_id&2)!=0)
     elif year=='2018':
         mask = (pt>20)&(abs(eta)<2.3)&(decayMode)&((_id&2)!=0)
     return mask


### PR DESCRIPTION
   * According to the Tau Twiki, we can use the same IDs for 2016, 2017 and 2018 if we want to be consistent, *as long as we are using the reprocessed data* (we are).
   * Tau pt > 20 GeV, |eta| < 2.3 cuts made consistent amongst all years.
   * VeryLoose ID+Isolation ("Tau_idMVAoldDM2017v2")